### PR TITLE
Just Remove ContainerCapability Completely 

### DIFF
--- a/XenAdmin/Dialogs/PropertiesDialog.cs
+++ b/XenAdmin/Dialogs/PropertiesDialog.cs
@@ -245,10 +245,10 @@ namespace XenAdmin.Dialogs
                     ShowTab(VMAdvancedEditPage = new VMAdvancedEditPage());
                 }
 
-                if (is_vm && Helpers.ContainerCapability(xenObject.Connection) && ((VM)xenObjectCopy).CanBeEnlightened())
+                if (is_vm && ((VM)xenObjectCopy).CanBeEnlightened())
                     ShowTab(VMEnlightenmentEditPage = new VMEnlightenmentEditPage());
 
-                if (is_vm && Helpers.ContainerCapability(xenObject.Connection) && ((VM)xenObjectCopy).CanHaveCloudConfigDrive())
+                if (is_vm && ((VM)xenObjectCopy).CanHaveCloudConfigDrive())
                     ShowTab(CloudConfigParametersPage = new Page_CloudConfigParameters());
 
                 if(is_VMSS)

--- a/XenAdmin/SettingsPanels/VMEnlightenmentEditPage.cs
+++ b/XenAdmin/SettingsPanels/VMEnlightenmentEditPage.cs
@@ -80,7 +80,6 @@ namespace XenAdmin.SettingsPanels
         public void SetXenObjects(IXenObject orig, IXenObject clone)
         {
             Trace.Assert(clone is VM);  // only VMs should show this page
-            Trace.Assert(Helpers.ContainerCapability(clone.Connection));  // If no container capability, we shouldn't see this page
 
             vm = (VM)clone;
 

--- a/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
+++ b/XenAdmin/Wizards/NewVMWizard/NewVMWizard.cs
@@ -253,7 +253,7 @@ namespace XenAdmin.Wizards.NewVMWizard
                     m_affinity = xenConnection.Resolve(selectedTemplate.affinity);
 
                 RemovePage(page_CloudConfigParameters);
-                if (selectedTemplate != null && selectedTemplate.CanHaveCloudConfigDrive() && Helpers.ContainerCapability(xenConnection))
+                if (selectedTemplate != null && selectedTemplate.CanHaveCloudConfigDrive())
                 {
                     AddAfterPage(page_6_Storage, page_CloudConfigParameters);
                 }

--- a/XenModel/Utils/Helpers.cs
+++ b/XenModel/Utils/Helpers.cs
@@ -1962,16 +1962,6 @@ namespace XenAdmin.Core
            return master != null && CreedenceOrGreater(master) && master.vSwitchNetworkBackend();
        }
 
-       public static bool ContainerCapability(IXenConnection connection)
-       {
-           var master = GetMaster(connection);
-           if (master == null)
-               return false;
-           if (ElyOrGreater(connection))
-               return master.AppliedUpdates().Any(update => update.Name().ToLower().StartsWith("xscontainer")); 
-           return CreamOrGreater(connection) && master.SuppPacks().Any(suppPack => suppPack.Name.ToLower().StartsWith("xscontainer")); 
-       }
-
        public static bool PvsCacheCapability(IXenConnection connection)
        {
            var master = GetMaster(connection);


### PR DESCRIPTION
Solve #45 by just removing all ContainerCapability checks, implicitly the same as returning true for all hosts.

This change will change behavior for XS hosts because the check would normally actually verify for XS and not XCP-ng. This PR just completely removes the verification.

Maybe want a better solution, in which case just kill this PR.