### PR TITLE
add some null checks

### DIFF
--- a/XenAdmin/TabPages/GeneralTabPage.cs
+++ b/XenAdmin/TabPages/GeneralTabPage.cs
@@ -1352,13 +1352,18 @@ namespace XenAdmin.TabPages
 
         private string PoolAdditionalLicenseString()
         {
-            if (licenseStatus.LicencedHost.edition == "xcp-ng")
-                return string.Empty;
-            else if (licenseStatus.CurrentState == LicenseStatus.HostState.Expired)
-                return Messages.LICENSE_EXPIRED;
-            else if (licenseStatus.CurrentState == LicenseStatus.HostState.Free)
-                return Messages.LICENSE_UNLICENSED;
-            else   
+            if (licenseStatus != null && licenseStatus.LicencedHost != null)
+            {
+                if (licenseStatus.LicencedHost.edition == "xcp-ng")
+                    return string.Empty;
+                else if (licenseStatus.CurrentState == LicenseStatus.HostState.Expired)
+                    return Messages.LICENSE_EXPIRED;
+                else if (licenseStatus.CurrentState == LicenseStatus.HostState.Free)
+                    return Messages.LICENSE_UNLICENSED;
+                else
+                    return string.Empty;
+            }
+            else
                 return string.Empty;
         }
 


### PR DESCRIPTION
This was the first workaround for the crash reported here:
https://github.com/xcp-ng/xenadmin/issues/89
