### PR TITLE
temporarly restrict license

### DIFF
--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -453,6 +453,9 @@ namespace XenAPI
 
         public static bool RestrictCorosync(Host h)
         {
+            // GFS2 and Clustering is not (yet) supported on XCP-ng
+            return true;
+
             return BoolKeyPreferTrue(h.license_params, "restrict_corosync");
         }
 

--- a/XenModel/XenAPI-Extensions/Host.cs
+++ b/XenModel/XenAPI-Extensions/Host.cs
@@ -453,9 +453,6 @@ namespace XenAPI
 
         public static bool RestrictCorosync(Host h)
         {
-            // GFS2 and Clustering is not (yet) supported on XCP-ng
-            return true;
-
             return BoolKeyPreferTrue(h.license_params, "restrict_corosync");
         }
 

--- a/XenModel/XenAPI/HelperXCP-ng.cs
+++ b/XenModel/XenAPI/HelperXCP-ng.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * 
+ *  Copyright(c) 2018 XCP-ng Project
+ * 
+ *  The 2-Clause BSD License
+ * 
+ *  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * 
+ *  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * 
+ *  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the distribution.
+ * 
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ *  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ *  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XenAPI
+{
+    public static class HelperXCP_ng
+    {
+        /// <summary>
+        /// Restricts the license to on XCP-ng usable features
+        /// </summary>
+        public static void RestrictLicenseToXCPng(Dictionary<string, string> licenseParams)
+        {
+            if (licenseParams.ContainsKey("restrict_corosync"))
+            {
+                licenseParams["restrict_corosync"] = "true";
+            }
+        }
+    }
+}

--- a/XenModel/XenAPI/Host.cs
+++ b/XenModel/XenAPI/Host.cs
@@ -3951,6 +3951,7 @@ namespace XenAPI
                 if (!Helper.AreEqual(value, _license_params))
                 {
                     _license_params = value;
+                    HelperXCP_ng.RestrictLicenseToXCPng(value);
                     Changed = true;
                     NotifyPropertyChanged("license_params");
                 }

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -374,6 +374,7 @@
       <DependentUpon>FriendlyErrorNames.resx</DependentUpon>
     </Compile>
     <Compile Include="XenAPI\GPU_group.cs" />
+    <Compile Include="XenAPI\HelperXCP-ng.cs" />
     <Compile Include="XenAPI\host_allowed_operations.cs" />
     <Compile Include="XenAPI\host_display.cs" />
     <Compile Include="XenAPI\ipv6_configuration_mode.cs" />


### PR DESCRIPTION
temporarly restrict license (to match real XCP-ng host features until it can report correctly)

* turn off corosync/cluster/gfs2