### PR TITLE
add pause/unpause for selected VM(s)

### DIFF
--- a/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
+++ b/XenAdmin/Commands/Controls/ContextMenuBuilder.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) Citrix Systems, Inc. 
+/* Copyright (c) Citrix Systems, Inc. 
  * All rights reserved. 
  * 
  * Redistribution and use in source and binary forms, 
@@ -866,6 +866,8 @@ namespace XenAdmin.Commands
                 items.AddIfEnabled(new StartVMCommand(mainWindow, selection), vm.power_state == vm_power_state.Halted);
                 items.AddIfEnabled(new ResumeVMCommand(mainWindow, selection));
                 items.AddIfEnabled(new SuspendVMCommand(mainWindow, selection));
+                items.AddIfEnabled(new PauseVMCommand(mainWindow, selection));
+                items.AddIfEnabled(new UnPauseVMCommand(mainWindow, selection));                
                 items.AddIfEnabled(new RebootVMCommand(mainWindow, selection));
                 items.AddSeparator();
 
@@ -1066,6 +1068,8 @@ namespace XenAdmin.Commands
                 items.AddIfEnabled(new StartVMCommand(mainWindow, selection));
                 items.AddIfEnabled(new ResumeVMCommand(mainWindow, selection));
                 items.AddIfEnabled(new SuspendVMCommand(mainWindow, selection));
+                items.AddIfEnabled(new PauseVMCommand(mainWindow, selection));
+                items.AddIfEnabled(new UnPauseVMCommand(mainWindow, selection));                
                 items.AddIfEnabled(new RebootVMCommand(mainWindow, selection));
                 items.AddSeparator();
                 items.AddIfEnabled(new ForceVMShutDownCommand(mainWindow, selection));

--- a/XenAdmin/Commands/Controls/VMLifeCycleToolStripMenuItem.cs
+++ b/XenAdmin/Commands/Controls/VMLifeCycleToolStripMenuItem.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) Citrix Systems, Inc. 
+/* Copyright (c) Citrix Systems, Inc. 
  * All rights reserved. 
  * 
  * Redistribution and use in source and binary forms, 
@@ -85,6 +85,16 @@ namespace XenAdmin.Commands
                 {
                     base.DropDownItems.Add(new CommandToolStripMenuItem(new SuspendVMCommand(mainWindow, selection)));
                 }
+
+                cmd = new UnPauseVMCommand(mainWindow, selection);
+                if (cmd.CanExecute())
+                {
+                    base.DropDownItems.Add(new CommandToolStripMenuItem(cmd));
+                }
+                else
+                {
+                    base.DropDownItems.Add(new CommandToolStripMenuItem(new PauseVMCommand(mainWindow, selection)));
+                }                
 
                 base.DropDownItems.Add(new CommandToolStripMenuItem(new RebootVMCommand(mainWindow, selection)));
                 base.DropDownItems.Add(new CommandToolStripMenuItem(new VMRecoveryModeCommand(mainWindow, selection)));

--- a/XenAdmin/Commands/PauseVMCommand.cs
+++ b/XenAdmin/Commands/PauseVMCommand.cs
@@ -1,0 +1,223 @@
+/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using XenAdmin.Actions;
+using XenAdmin.Properties;
+using XenAPI;
+using XenAdmin.Dialogs;
+using XenAdmin.Actions.VMActions;
+
+
+namespace XenAdmin.Commands
+{
+    /// <summary>
+    /// Shuts down the selected VMs. Shows a confirmation dialog.
+    /// </summary>
+    internal class PauseVMCommand : VMLifeCycleCommand
+    {
+        /// <summary>
+        /// Initializes a new instance of this Command. The parameter-less constructor is required if 
+        /// this Command is to be attached to a ToolStrip menu item or button. It should not be used in any other scenario.
+        /// </summary>
+        public PauseVMCommand()
+        {
+        }
+
+        public PauseVMCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection)
+            : base(mainWindow, selection)
+        {
+        }
+
+        public PauseVMCommand(IMainWindow mainWindow, VM vm)
+            : base(mainWindow, vm)
+        {
+        }
+
+        public PauseVMCommand(IMainWindow mainWindow, VM vm, Control parent)
+            : base(mainWindow, vm, parent)
+        {
+        }
+
+        protected override bool CanExecute(VM vm)
+        {
+            return vm != null && vm.allowed_operations != null && vm.allowed_operations.Contains(vm_operations.pause);
+        }
+
+        protected override void Execute(List<VM> vms)
+        {
+            //fixme: add new message to Messages
+            //RunAction(vms, Messages.ACTION_VM_PAUSING, Messages.ACTION_VM_PAUSING, Messages.ACTION_VM_PAUSED, null);
+            RunAction(vms, "VM pausing", "VM pausing", "VM paused", null);
+        }
+
+        public override string MenuText
+        {
+            get
+            {
+                return Messages.MAINWINDOW_PAUSE;
+                //return "Pause to RAM (" + ShortcutKeyDisplayString + ") ";
+            }
+        }
+
+        protected override string EnabledToolTipText
+        {
+            get
+            {
+                //fixme: add new message to Messages
+                //return Messages.MAINWINDOW_TOOLBAR_PAUSEVM;
+                return "Pause to RAM (" + ShortcutKeyDisplayString + ") ";
+            }
+        }
+
+        public override Image MenuImage
+        {
+            get
+            {
+                return Images.StaticImages._000_SuspendVM_h32bit_16;
+            }
+        }
+
+        public override Image ToolBarImage
+        {
+            get
+            {
+                return Images.StaticImages._000_SuspendVM_h32bit_16;
+            }
+        }
+
+        public override Keys ShortcutKeys
+        {
+            get
+            {
+                return Keys.Control | Keys.P;
+            }
+        }
+
+        public override string ShortcutKeyDisplayString
+        {
+            get
+            {
+                //fixme: add new message to Messages
+                //return Messages.MAINWINDOW_CTRL_P;
+                return "CTRL + P";
+            }
+        }
+
+        protected override bool ConfirmationRequired
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        protected override string ConfirmationDialogText
+        {
+            get
+            {
+                SelectedItemCollection selection = GetSelection();
+                if (selection.Count == 1)
+                {
+                    VM vm = (VM)selection[0].XenObject;
+                    //fixme: add new message to Messages
+                    //return vm.HAIsProtected() ? Messages.HA_CONFIRM_PAUSE_VM : Messages.CONFIRM_PAUSE_VM;
+                    return vm.HAIsProtected() ? "Confirm HA Pause VM" : "Confirm Pause VM";
+                }
+
+                //fixme: add new message to Messages
+                //return Messages.CONFIRM_PAUSE_VMS;
+                return "Confirm pausing VMs";
+            }
+        }
+
+        protected override string ConfirmationDialogTitle
+        {
+            get
+            {
+                if (GetSelection().Count == 1)
+                {
+                    //fixme: add new message to Messages
+                    //return Messages.CONFIRM_PAUSE_VM_TITLE;
+                    return "Confirm Pause VM";
+                }
+                //fixme: add new message to Messages
+                //return Messages.CONFIRM_PAUSE_VMS_TITLE;
+                return "Confirm Pause VMs";
+            }
+        }
+
+        protected override string ConfirmationDialogHelpId
+        {
+            get { return "WarningVmLifeCyclePause"; }
+        }
+
+        protected override string GetCantExecuteReasonCore(SelectedItem item)
+        {
+            VM vm = item.XenObject as VM;
+            if (vm == null)
+                return base.GetCantExecuteReasonCore(item);
+
+            switch (vm.power_state)
+            {
+                case vm_power_state.Halted:
+                    return Messages.VM_SHUT_DOWN;
+                case vm_power_state.Paused:
+                    return Messages.VM_PAUSED;
+                case vm_power_state.Suspended:
+                    return Messages.VM_SUSPENDED;
+                case vm_power_state.unknown:
+                    return base.GetCantExecuteReasonCore(item);
+            }
+
+            return GetCantExecuteNoToolsOrDriversReasonCore(item) ?? base.GetCantExecuteReasonCore(item);
+        }
+
+        protected override CommandErrorDialog GetErrorDialogCore(IDictionary<SelectedItem, string> cantExecuteReasons)
+        {
+            foreach (VM vm in GetSelection().AsXenObjects<VM>())
+            {
+                if (!CanExecute(vm) && vm.power_state != vm_power_state.Halted)
+                {
+                    return new CommandErrorDialog(Messages.ERROR_DIALOG_SHUTDOWN_VM_TITLE, Messages.ERROR_DIALOG_SHUTDOWN_VMS_TITLE, cantExecuteReasons);
+                }
+            }
+            return null;
+        }
+
+        protected override AsyncAction BuildAction(VM vm)
+        {
+            return new VMPause(vm);
+        }
+    }
+}

--- a/XenAdmin/Commands/UnPauseVMCommand.cs
+++ b/XenAdmin/Commands/UnPauseVMCommand.cs
@@ -1,0 +1,211 @@
+/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using System.Collections.Generic;
+using System.Drawing;
+using System.Windows.Forms;
+using XenAdmin.Actions;
+using XenAdmin.Properties;
+using XenAPI;
+using XenAdmin.Dialogs;
+using XenAdmin.Actions.VMActions;
+
+
+namespace XenAdmin.Commands
+{
+    /// <summary>
+    /// Shuts down the selected VMs. Shows a confirmation dialog.
+    /// </summary>
+    internal class UnPauseVMCommand : VMLifeCycleCommand
+    {
+        /// <summary>
+        /// Initializes a new instance of this Command. The parameter-less constructor is required if 
+        /// this Command is to be attached to a ToolStrip menu item or button. It should not be used in any other scenario.
+        /// </summary>
+        public UnPauseVMCommand()
+        {
+        }
+
+        public UnPauseVMCommand(IMainWindow mainWindow, IEnumerable<SelectedItem> selection)
+            : base(mainWindow, selection)
+        {
+        }
+
+        public UnPauseVMCommand(IMainWindow mainWindow, VM vm)
+            : base(mainWindow, vm)
+        {
+        }
+
+        public UnPauseVMCommand(IMainWindow mainWindow, VM vm, Control parent)
+            : base(mainWindow, vm, parent)
+        {
+        }
+
+        protected override bool CanExecute(VM vm)
+        {
+            return vm != null && vm.allowed_operations != null && vm.allowed_operations.Contains(vm_operations.unpause);
+        }
+
+        protected override void Execute(List<VM> vms)
+        {
+            //fixme: add new message to Messages
+            //RunAction(vms, Messages.ACTION_VM_UNPAUSING, Messages.ACTION_VM_UNPAUSING, Messages.ACTION_VM_UNPAUSED, null);
+            RunAction(vms, "Unpause", "VM unpausing", "VM unpaused", null);
+        }
+
+        public override string MenuText
+        {
+            get
+            {
+                //fixme: add new message to Messages
+                //return Messages.MAINWINDOW_UNPAUSE;
+                return "Unpause";
+            }
+        }
+
+        protected override string EnabledToolTipText
+        {
+            get
+            {
+                //fixme: add new message to Messages
+                //return Messages.MAINWINDOW_TOOLBAR_UNPAUSEVM;
+                return "Unpause (" + ShortcutKeyDisplayString + ") ";
+            }
+        }
+
+        public override Image MenuImage
+        {
+            get
+            {
+                return Images.StaticImages._000_Resumed_h32bit_16;
+            }
+        }
+
+        public override Keys ShortcutKeys
+        {
+            get
+            {
+                return Keys.Control | Keys.P;
+            }
+        }
+
+        public override string ShortcutKeyDisplayString
+        {
+            get
+            {
+                //return Messages.MAINWINDOW_CTRL_E;
+                return "CTRL + P";
+            }
+        }
+
+        protected override bool ConfirmationRequired
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        protected override string ConfirmationDialogText
+        {
+            get
+            {
+                SelectedItemCollection selection = GetSelection();
+                if (selection.Count == 1)
+                {
+                    VM vm = (VM)selection[0].XenObject;
+                    //return vm.HAIsProtected() ? Messages.HA_CONFIRM_SHUTDOWN_VM : Messages.CONFIRM_SHUTDOWN_VM;
+                    return vm.HAIsProtected() ? "Confirm HA Unpause VM" : "Confirm Unpause VM";
+                }
+
+                //return Messages.CONFIRM_SHUTDOWN_VMS;
+                return "Confirm unpausing VMs";
+            }
+        }
+
+        protected override string ConfirmationDialogTitle
+        {
+            get
+            {
+                if (GetSelection().Count == 1)
+                {
+                    //return Messages.CONFIRM_SHUTDOWN_VM_TITLE;
+                    return "Confirm Unpause VM";
+                }
+                //return Messages.CONFIRM_SHUTDOWN_VMS_TITLE;
+                return "Confirm Unpause VMs";
+            }
+        }
+
+        protected override string ConfirmationDialogHelpId
+        {
+            get { return "WarningVmLifeCyclePause"; }
+        }
+
+        protected override string GetCantExecuteReasonCore(SelectedItem item)
+        {
+            VM vm = item.XenObject as VM;
+            if (vm == null)
+                return base.GetCantExecuteReasonCore(item);
+
+            switch (vm.power_state)
+            {
+                case vm_power_state.Halted:
+                    return Messages.VM_SHUT_DOWN;
+                case vm_power_state.Running:
+                    return "VM is running";
+                case vm_power_state.Suspended:
+                    return Messages.VM_SUSPENDED;
+                case vm_power_state.unknown:
+                    return base.GetCantExecuteReasonCore(item);
+            }
+
+            return GetCantExecuteNoToolsOrDriversReasonCore(item) ?? base.GetCantExecuteReasonCore(item);
+        }
+
+        protected override CommandErrorDialog GetErrorDialogCore(IDictionary<SelectedItem, string> cantExecuteReasons)
+        {
+            foreach (VM vm in GetSelection().AsXenObjects<VM>())
+            {
+                if (!CanExecute(vm) && vm.power_state != vm_power_state.Paused)
+                {
+                    return new CommandErrorDialog(Messages.ERROR_DIALOG_SHUTDOWN_VM_TITLE, Messages.ERROR_DIALOG_SHUTDOWN_VMS_TITLE, cantExecuteReasons);
+                }
+            }
+            return null;
+        }
+
+        protected override AsyncAction BuildAction(VM vm)
+        {
+            return new VMUnPause(vm);
+        }
+    }
+}

--- a/XenAdmin/MainWindow.Designer.cs
+++ b/XenAdmin/MainWindow.Designer.cs
@@ -116,6 +116,8 @@ namespace XenAdmin
             this.RebootToolbarButton = new XenAdmin.Commands.CommandToolStripButton();
             this.resumeToolStripButton = new XenAdmin.Commands.CommandToolStripButton();
             this.SuspendToolbarButton = new XenAdmin.Commands.CommandToolStripButton();
+            this.PauseVmToolbarButton = new XenAdmin.Commands.CommandToolStripButton();
+            this.UnpauseVmToolbarButton = new XenAdmin.Commands.CommandToolStripButton();
             this.ForceShutdownToolbarButton = new XenAdmin.Commands.CommandToolStripButton();
             this.ForceRebootToolbarButton = new XenAdmin.Commands.CommandToolStripButton();
             this.stopContainerToolStripButton = new XenAdmin.Commands.CommandToolStripButton();
@@ -615,6 +617,8 @@ namespace XenAdmin
             this.RebootToolbarButton,
             this.resumeToolStripButton,
             this.SuspendToolbarButton,
+            this.PauseVmToolbarButton,
+            this.UnpauseVmToolbarButton,
             this.ForceShutdownToolbarButton,
             this.ForceRebootToolbarButton,
             this.stopContainerToolStripButton,
@@ -735,6 +739,21 @@ namespace XenAdmin
             resources.ApplyResources(this.SuspendToolbarButton, "SuspendToolbarButton");
             this.SuspendToolbarButton.Image = global::XenAdmin.Properties.Resources._000_Paused_h32bit_24;
             this.SuspendToolbarButton.Name = "SuspendToolbarButton";
+            // 
+            // PauseVmToolbarButton
+            // 
+            this.PauseVmToolbarButton.Command = new XenAdmin.Commands.PauseVMCommand();
+            resources.ApplyResources(this.PauseVmToolbarButton, "PauseVmToolbarButton");
+            this.PauseVmToolbarButton.Image = global::XenAdmin.Properties.Resources._000_Paused_h32bit_24;
+            this.PauseVmToolbarButton.Name = "PauseVmToolbarButton";
+            // 
+            // UnpauseVmToolbarButton
+            // 
+            this.UnpauseVmToolbarButton.Command = new XenAdmin.Commands.UnPauseVMCommand();
+            resources.ApplyResources(this.UnpauseVmToolbarButton, "UnpauseVmToolbarButton");
+            this.UnpauseVmToolbarButton.Image = global::XenAdmin.Properties.Resources._000_Resumed_h32bit_24;
+            this.UnpauseVmToolbarButton.Name = "UnpauseVmToolbarButton";
+            // 
             // 
             // ForceShutdownToolbarButton
             // 
@@ -1953,6 +1972,8 @@ namespace XenAdmin
         private CommandToolStripButton AddServerToolbarButton;
         private CommandToolStripButton RebootToolbarButton;
         private CommandToolStripButton SuspendToolbarButton;
+        private CommandToolStripButton PauseVmToolbarButton;
+        private CommandToolStripButton UnpauseVmToolbarButton;
         private CommandToolStripButton ForceRebootToolbarButton;
         private CommandToolStripButton ForceShutdownToolbarButton;
         private System.Windows.Forms.ToolTip statusToolTip;

--- a/XenAdmin/MainWindow.cs
+++ b/XenAdmin/MainWindow.cs
@@ -1,4 +1,4 @@
-﻿/* Copyright (c) Citrix Systems, Inc. 
+/* Copyright (c) Citrix Systems, Inc. 
  * All rights reserved. 
  * 
  * Redistribution and use in source and binary forms, 
@@ -1413,6 +1413,9 @@ namespace XenAdmin
 
             resumeToolStripButton.Available = resumeToolStripButton.Enabled;
             SuspendToolbarButton.Available = SuspendToolbarButton.Enabled || (!resumeToolStripButton.Available && !containerButtonsAvailable);
+
+            UnpauseVmToolbarButton.Available = UnpauseVmToolbarButton.Enabled;
+            PauseVmToolbarButton.Available = PauseVmToolbarButton.Enabled || (!UnpauseVmToolbarButton.Available);            
 
             ForceRebootToolbarButton.Available = ((ForceVMRebootCommand)ForceRebootToolbarButton.Command).ShowOnMainToolBar;
             ForceShutdownToolbarButton.Available = ((ForceVMShutDownCommand)ForceShutdownToolbarButton.Command).ShowOnMainToolBar;

--- a/XenAdmin/MainWindow.ja.resx
+++ b/XenAdmin/MainWindow.ja.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1815,6 +1815,60 @@
   <data name="pauseContainerToolStripButton.ToolTipText" xml:space="preserve">
     <value>Docker コンテナの一時停止</value>
   </data>
+  <data name="UnpauseVmToolbarButton.ToolTipText" xml:space="preserve">
+    <value>Unpause VM (Ctrl+P)</value>
+  </data>
+  <data name="&gt;&gt;UnpauseVmToolbarButton.Name" xml:space="preserve">
+    <value>UnpauseVmToolbarButton</value>
+  </data>
+  <data name="&gt;&gt;UnpauseVmToolbarButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandToolStripButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 28</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Text" xml:space="preserve">
+    <value>Unpause</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;PauseVmToolbarButton.Name" xml:space="preserve">
+    <value>PauseVmToolbarButton</value>
+  </data>
+  <data name="&gt;&gt;PauseVmToolbarButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandToolStripButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="PauseVmToolbarButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="PauseVmToolbarButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="PauseVmToolbarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="PauseVmToolbarButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 28</value>
+  </data>
+  <data name="PauseVmToolbarButton.Text" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="PauseVmToolbarButton.ToolTipText" xml:space="preserve">
+    <value>Pause VM to RAM (Ctrl+P)</value>
+  </data>
+  <data name="PauseVmToolbarButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data> 
   <data name="ToolStrip.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 24</value>
   </data>

--- a/XenAdmin/MainWindow.resx
+++ b/XenAdmin/MainWindow.resx
@@ -1815,6 +1815,60 @@
   <data name="pauseContainerToolStripButton.ToolTipText" xml:space="preserve">
     <value>Pause Docker Container</value>
   </data>
+  <data name="UnpauseVmToolbarButton.ToolTipText" xml:space="preserve">
+    <value>Unpause VM (Ctrl+P)</value>
+  </data>
+  <data name="&gt;&gt;UnpauseVmToolbarButton.Name" xml:space="preserve">
+    <value>UnpauseVmToolbarButton</value>
+  </data>
+  <data name="&gt;&gt;UnpauseVmToolbarButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandToolStripButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 28</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Text" xml:space="preserve">
+    <value>Unpause</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;PauseVmToolbarButton.Name" xml:space="preserve">
+    <value>PauseVmToolbarButton</value>
+  </data>
+  <data name="&gt;&gt;PauseVmToolbarButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandToolStripButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="PauseVmToolbarButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="PauseVmToolbarButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="PauseVmToolbarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="PauseVmToolbarButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 28</value>
+  </data>
+  <data name="PauseVmToolbarButton.Text" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="PauseVmToolbarButton.ToolTipText" xml:space="preserve">
+    <value>Pause VM to RAM (Ctrl+P)</value>
+  </data>
+  <data name="PauseVmToolbarButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data> 
   <data name="ToolStrip.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 24</value>
   </data>

--- a/XenAdmin/MainWindow.zh-CN.resx
+++ b/XenAdmin/MainWindow.zh-CN.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1815,6 +1815,60 @@
   <data name="pauseContainerToolStripButton.ToolTipText" xml:space="preserve">
     <value>暂停 Docker 容器</value>
   </data>
+  <data name="UnpauseVmToolbarButton.ToolTipText" xml:space="preserve">
+    <value>Unpause VM (Ctrl+P)</value>
+  </data>
+  <data name="&gt;&gt;UnpauseVmToolbarButton.Name" xml:space="preserve">
+    <value>UnpauseVmToolbarButton</value>
+  </data>
+  <data name="&gt;&gt;UnpauseVmToolbarButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandToolStripButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>73, 28</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.Text" xml:space="preserve">
+    <value>Unpause</value>
+  </data>
+  <data name="UnpauseVmToolbarButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="&gt;&gt;PauseVmToolbarButton.Name" xml:space="preserve">
+    <value>PauseVmToolbarButton</value>
+  </data>
+  <data name="&gt;&gt;PauseVmToolbarButton.Type" xml:space="preserve">
+    <value>XenAdmin.Commands.CommandToolStripButton, XenCenterMain, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="PauseVmToolbarButton.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Tahoma, 8.25pt</value>
+  </data>
+  <data name="PauseVmToolbarButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="PauseVmToolbarButton.ImageTransparentColor" type="System.Drawing.Color, System.Drawing">
+    <value>Magenta</value>
+  </data>
+  <data name="PauseVmToolbarButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 28</value>
+  </data>
+  <data name="PauseVmToolbarButton.Text" xml:space="preserve">
+    <value>Pause</value>
+  </data>
+  <data name="PauseVmToolbarButton.ToolTipText" xml:space="preserve">
+    <value>Pause VM to RAM (Ctrl+P)</value>
+  </data>
+  <data name="PauseVmToolbarButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data> 
   <data name="ToolStrip.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 24</value>
   </data>

--- a/XenAdmin/XenAdmin.csproj
+++ b/XenAdmin/XenAdmin.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -132,6 +132,8 @@
     <Compile Include="Commands\PauseDockerContainerCommand.cs" />
     <Compile Include="Commands\StopDockerContainerCommand.cs" />
     <Compile Include="Commands\StartDockerContainerCommand.cs" />
+    <Compile Include="Commands\PauseVMCommand.cs" />
+    <Compile Include="Commands\UnPauseVMCommand.cs" />
     <Compile Include="Commands\Controls\EditPropertiesToolStripMenuItem.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/XenModel/Actions/VM/VMPauseAction.cs
+++ b/XenModel/Actions/VM/VMPauseAction.cs
@@ -1,0 +1,71 @@
+﻿/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using XenAPI;
+using XenAdmin.Core;
+
+namespace XenAdmin.Actions.VMActions
+{
+    public abstract class VMPauseAction : PureAsyncAction
+    {
+        protected VMPauseAction(VM vm,string title)
+            : base(vm.Connection, title)
+        {
+            //this.Description = Messages.ACTION_PREPARING;
+            this.Description = "Pause VM";
+            this.VM = vm;
+            this.Host = vm.Home();
+            this.Pool = Core.Helpers.GetPool(vm.Connection);
+        }
+    }
+
+    public class VMPause : VMPauseAction
+    {
+        public VMPause(VM vm)
+            : base(vm, string.Format("Pause VM", vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
+        {
+        }
+
+        protected override void Run()
+        {
+            //fixme: add new message to Messages
+            //this.Description = Messages.ACTION_VM_SHUTTING_DOWN;
+            this.Description = "pause VM";
+
+            RelatedTask = VM.async_pause(Session, VM.opaque_ref);
+            PollToCompletion(0, 100);
+            //fixme: add new message to Messages
+            //this.Description = Messages.ACTION_VM_SHUT_DOWN;
+            this.Description = "VM paused";
+        }
+    }
+
+}

--- a/XenModel/Actions/VM/VMUnPauseAction.cs
+++ b/XenModel/Actions/VM/VMUnPauseAction.cs
@@ -1,0 +1,72 @@
+/* Copyright (c) Citrix Systems, Inc. 
+ * All rights reserved. 
+ * 
+ * Redistribution and use in source and binary forms, 
+ * with or without modification, are permitted provided 
+ * that the following conditions are met: 
+ * 
+ * *   Redistributions of source code must retain the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer. 
+ * *   Redistributions in binary form must reproduce the above 
+ *     copyright notice, this list of conditions and the 
+ *     following disclaimer in the documentation and/or other 
+ *     materials provided with the distribution. 
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+ * SUCH DAMAGE.
+ */
+
+using XenAPI;
+using XenAdmin.Core;
+
+namespace XenAdmin.Actions.VMActions
+{
+    public abstract class VMUnPauseAction : PureAsyncAction
+    {
+        protected VMUnPauseAction(VM vm,string title)
+            : base(vm.Connection, title)
+        {
+            //fixme: add new message to Messages
+            //this.Description = Messages.ACTION_PREPARING;
+            this.Description = "Unpause VM";
+            this.VM = vm;
+            this.Host = vm.Home();
+            this.Pool = Core.Helpers.GetPool(vm.Connection);
+        }
+    }
+
+    public class VMUnPause : VMUnPauseAction
+    {
+        public VMUnPause(VM vm)
+            : base(vm, string.Format("Unpause VM", vm.Name(), vm.Home() == null ? Helpers.GetName(vm.Connection) : vm.Home().Name()))
+        {
+        }
+
+        protected override void Run()
+        {
+            //fixme: add new message to Messages
+            //this.Description = Messages.ACTION_VM_UNPAUSING;
+            this.Description = "unpause VM";
+
+            RelatedTask = VM.async_unpause(Session, VM.opaque_ref);
+            PollToCompletion(0, 100);
+            //fixme: add new message to Messages
+            //this.Description = Messages.ACTION_VM_UNPAUSED;
+            this.Description = "VM unpaused";
+        }
+    }
+
+}

--- a/XenModel/XenModel.csproj
+++ b/XenModel/XenModel.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -161,6 +161,8 @@
     <Compile Include="Actions\VM\VMCrossPoolMigrateAction.cs" />
     <Compile Include="Actions\VM\VMSnapshotCreateAction.cs" />
     <Compile Include="Actions\VM\VMStartAction.cs" />
+    <Compile Include="Actions\VM\VMPauseAction.cs" />
+    <Compile Include="Actions\VM\VMUnPauseAction.cs" />
     <Compile Include="Actions\WLB\WlbRetrieveVmRecommendationsAction.cs" />
     <Compile Include="Actions\ZipStatusReportAction.cs" />
     <Compile Include="Alerts\Types\Alert.cs" />


### PR DESCRIPTION
This adds the feature wish for pausing/unpausing VMs to RAM.

Added:

- commands
- actions
- context menu items
- menu items
- toolbar buttons
- Shortcut (CTRL + P for pause/unpause)
- MainWindow resources

I used an existing small Icon, but on the toolbar it doesn't look good. So it should be replaced by a new one. I chosed this one, as it is at least diefferent to the existing suspend icon.

Some Messages are hardcoded in the commands and could be transferred to the central Messages.

The Mainwindow resources for other languages are not translated, I just added the same english ones.

