### PR TITLE
add ext4 and xfs as SR type

### DIFF
--- a/XenModel/FriendlyNames.ja.resx
+++ b/XenModel/FriendlyNames.ja.resx
@@ -357,6 +357,12 @@
   <data name="Label-SR.SRTypes-ext" xml:space="preserve">
     <value>Ext3</value>
   </data>
+  <data name="Label-SR.SRTypes-ext4" xml:space="preserve">
+    <value>Ext4</value>
+  </data>
+  <data name="Label-SR.SRTypes-xfs" xml:space="preserve">
+    <value>XFS</value>
+  </data>  
   <data name="Label-SR.SRTypes-iscsi" xml:space="preserve">
     <value>VDI-per-LUN iSCSI</value>
   </data>

--- a/XenModel/FriendlyNames.resx
+++ b/XenModel/FriendlyNames.resx
@@ -357,6 +357,12 @@
   <data name="Label-SR.SRTypes-ext" xml:space="preserve">
     <value>Ext3</value>
   </data>
+  <data name="Label-SR.SRTypes-ext4" xml:space="preserve">
+    <value>Ext4</value>
+  </data>
+  <data name="Label-SR.SRTypes-xfs" xml:space="preserve">
+    <value>XFS</value>
+  </data>
   <data name="Label-SR.SRTypes-iscsi" xml:space="preserve">
     <value>VDI-per-LUN iSCSI</value>
   </data>

--- a/XenModel/FriendlyNames.zh-CN.resx
+++ b/XenModel/FriendlyNames.zh-CN.resx
@@ -357,6 +357,12 @@
   <data name="Label-SR.SRTypes-ext" xml:space="preserve">
     <value>Ext3</value>
   </data>
+  <data name="Label-SR.SRTypes-ext4" xml:space="preserve">
+    <value>Ext4</value>
+  </data>
+  <data name="Label-SR.SRTypes-xfs" xml:space="preserve">
+    <value>XFS</value>
+  </data>
   <data name="Label-SR.SRTypes-iscsi" xml:space="preserve">
     <value>VDI-per-LUN iSCSI</value>
   </data>

--- a/XenModel/XenAPI-Extensions/SR.cs
+++ b/XenModel/XenAPI-Extensions/SR.cs
@@ -49,13 +49,13 @@ namespace XenAPI
         /// </summary>
         public enum SRTypes
         {
-            local, ext, lvmoiscsi, iso, nfs, lvm, netapp, udev, lvmofc,
+            local, ext, ext4, lvmoiscsi, iso, nfs, lvm, netapp, udev, lvmofc,
             lvmohba, egenera, egeneracd, dummy, unknown, equal, cslg, shm,
             iscsi,
             ebs, rawhba,
             smb, lvmofcoe, gfs2,
             nutanix, nutanixiso, 
-            tmpfs
+            tmpfs, xfs
         }
 
         public const string Content_Type_ISO = "iso";
@@ -244,7 +244,9 @@ namespace XenAPI
                 || type == SRTypes.cslg
                 || type == SRTypes.smb
                 || type == SRTypes.lvmofcoe
-                || type == SRTypes.gfs2;
+                || type == SRTypes.gfs2
+                || type == SRTypes.ext4
+                || type == SRTypes.xfs;
         }
 
         public bool IsLocalSR()
@@ -255,7 +257,8 @@ namespace XenAPI
                    || typ == SRTypes.lvm
                    || typ == SRTypes.udev
                    || typ == SRTypes.egeneracd
-                   || typ == SRTypes.dummy;
+                   || typ == SRTypes.dummy
+                   || typ == SRTypes.ext4;
         }
 
         public bool ShowForgetWarning()


### PR DESCRIPTION
Initial changes.
Detects the ext4 SR as Ext4.

Do we wnat to be able to detach ext4 storage?
Currently it would be possible if it is listed in  "CanCreateWithXenCenter".