### PR TITLE
Fast fix for new xcp-ng 8.2

### DIFF
--- a/XenModel/XenAPI/ApiVersion.cs
+++ b/XenModel/XenAPI/ApiVersion.cs
@@ -62,8 +62,9 @@ namespace XenAPI
         API_2_12 = 23, //Citrix Hypervisor 8.0 (naples)
         API_2_13 = 24, //Unreleased (oslo)
         API_2_14 = 25, //Citrix Hypervisor 8.1 (quebec)
-        API_2_15 = 26, //Unreleased (stockholm)
-        LATEST = 26,
+        API_2_15 = 26, //Citrix Hypervisor 8.2 (stockholm)
+        API_2_16 = 27, //unreleased (stockholm)
+        LATEST = 27,
         UNKNOWN = 99
     }
 
@@ -125,6 +126,8 @@ namespace XenAPI
                     return "2.14";
                 case API_Version.API_2_15:
                     return "2.15";
+                case API_Version.API_2_16:
+                    return "2.16";
                 default:
                     return "Unknown";
             }
@@ -179,4 +182,4 @@ namespace XenAPI
             return APIVersionCompare(session, v) >= 0;
         }
     }
-}
+}


### PR DESCRIPTION
It is just workaround to start XCP-ng Center without error.