### PR TITLE
Fix: persist pool auto_poweron when enabling host autostart

### DIFF
--- a/XenModel/Actions/Host/ChangeHostAutostartAction.cs
+++ b/XenModel/Actions/Host/ChangeHostAutostartAction.cs
@@ -34,6 +34,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using XenAdmin.Actions;
+using XenAdmin.Core;
 using XenAdmin.Network;
 using XenAPI;
 
@@ -47,10 +48,19 @@ namespace XenAdmin.Actions
         {
             Host = host;
             newValue = enable;
+
+            ApiMethodsToRoleCheck.AddWithKey("pool.remove_from_other_config", "auto_poweron");
+            ApiMethodsToRoleCheck.AddWithKey("pool.add_to_other_config", "auto_poweron");
         }
 
         protected override void Run()
         {
+            var pool = Helpers.GetPoolOfOne(Connection);
+            if (pool == null)
+                return;
+            Pool.remove_from_other_config(Session, pool.opaque_ref, "auto_poweron");
+            Pool.add_to_other_config(Session, pool.opaque_ref, "auto_poweron", newValue ? "true" : "false");
+
             Host.SetVmAutostartEnabled(newValue);
         }
     }


### PR DESCRIPTION
## Problem

Enabling **"Autostart"** from the Host properties page does not persist the pool-wide `other_config:auto_poweron` flag.

The UI reflects the change, but:

``` bash
xe pool-param-get uuid=$(xe pool-list --minimal) param-name=other-config
```

still reports:

    auto_poweron: false

As a result, VMs do not start automatically after host reboot.

------------------------------------------------------------------------

## Root Cause

`ChangeHostAutostartAction` only calls:

``` csharp
Host.SetVmAutostartEnabled()
```

which updates the local cached `Pool.other_config` dictionary but never commits the change to the server via XenAPI.

Therefore, the setting is not persisted on the pool.

------------------------------------------------------------------------

## Fix

Update `ChangeHostAutostartAction` to persist the pool flag using XenAPI